### PR TITLE
group pending transfers by asset id

### DIFF
--- a/store/wallet/wallet.go
+++ b/store/wallet/wallet.go
@@ -198,6 +198,22 @@ func (s *walletStore) ListPendingTransfers(_ context.Context) ([]*core.Transfer,
 		return nil, err
 	}
 
+	// filter by asset id
+	filter := make(map[string]bool)
+	var idx int
+
+	for _, t := range transfers {
+		if filter[t.AssetID] {
+			continue
+		}
+
+		transfers[idx] = t
+		filter[t.AssetID] = true
+		idx++
+	}
+
+	transfers = transfers[:idx]
+
 	for _, t := range transfers {
 		afterFindTransfer(t)
 	}


### PR DESCRIPTION
同一 asset id 的 transfers，必须按顺序处理，前面的处理成功了，再处理下一条。